### PR TITLE
API for managing SIP models

### DIFF
--- a/invenio_sipstore/admin.py
+++ b/invenio_sipstore/admin.py
@@ -33,18 +33,15 @@ class SIPModelView(ModelView):
     can_view_details = True
     column_display_all_relations = True
     column_list = (
-        'sip_format', 'content', 'user_id', 'agent'
+        'user_id', 'agent'
     )
     column_labels = dict(
-        sip_format='SIP Format',
-        content='Content',
         user_id='User ID',
         agent='Agent'
     )
     column_filters = (
-        'sip_format', 'content', 'user_id',
+        'user_id',
     )
-    column_searchable_list = ('sip_format', 'content')
     page_size = 25
 
 

--- a/invenio_sipstore/admin.py
+++ b/invenio_sipstore/admin.py
@@ -21,7 +21,7 @@
 
 from flask_admin.contrib.sqla import ModelView
 
-from .models import SIP, RecordSIP, SIPFile
+from .models import SIP, RecordSIP, SIPFile, SIPMetadata
 
 
 class SIPModelView(ModelView):
@@ -33,14 +33,16 @@ class SIPModelView(ModelView):
     can_view_details = True
     column_display_all_relations = True
     column_list = (
-        'user_id', 'agent'
+        'user_id', 'agent', 'archivable', 'archived'
     )
     column_labels = dict(
         user_id='User ID',
-        agent='Agent'
+        agent='Agent',
+        archivable='Archivable',
+        archived='Archived'
     )
     column_filters = (
-        'user_id',
+        'user_id', 'archivable', 'archived'
     )
     page_size = 25
 
@@ -52,6 +54,31 @@ class SIPFileModelView(ModelView):
     can_edit = False
     can_delete = False
     can_view_details = True
+    page_size = 25
+
+
+class SIPMetadataModelView(ModelView):
+    """ModelView for the SIPMetadata."""
+
+    can_create = False
+    can_edit = False
+    can_delete = False
+    can_view_details = True
+    column_display_all_relations = True
+    column_list = (
+        'format',
+        'content',
+        'sip.agent',
+        'sip.archivable',
+        'sip.archived'
+    )
+    column_labels = {
+        'format': 'Format',
+        'content': 'Content',
+        'sip.agent': 'Agent',
+        'sip.archivable': 'Archivable',
+        'sip.archived': 'Archived'
+    }
     page_size = 25
 
 
@@ -74,6 +101,11 @@ sipfile_adminview = dict(
     modelview=SIPFileModelView,
     model=SIPFile,
     name='SIPFile',
+    category='Records')
+sipmetadata_adminview = dict(
+    modelview=SIPMetadataModelView,
+    model=SIPMetadata,
+    name='SIPMetadata',
     category='Records')
 recordsip_adminview = dict(
     modelview=RecordSIPModelView,

--- a/invenio_sipstore/api.py
+++ b/invenio_sipstore/api.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""API for Invenio-SIPStore."""
+
+import json
+
+from flask import current_app, has_request_context, request
+from flask_login import current_user
+from invenio_db import db
+from werkzeug.utils import import_string
+
+from invenio_sipstore.models import SIP as SIP_
+from invenio_sipstore.models import RecordSIP as RecordSIP_
+from invenio_sipstore.models import SIPFile, SIPMetadata
+from invenio_sipstore.signals import sipstore_created
+
+
+class SIP(object):
+    """API for managing SIPs."""
+
+    def __init__(self, sip):
+        """Constructor.
+
+        :param sip: the SIP model associated
+        :type sip: :py:data:`invenio_sipstore.models.SIP`
+        """
+        self.model = sip
+
+    @staticmethod
+    def _build_agent_info():
+        """Build the SIP agent info.
+
+        This method can be changed in the config to suit your needs, see
+        :py:data:`invenio_sipstore.config.SIPSTORE_AGENT_FACTORY`
+
+        :returns: Agent information regarding the SIP.
+        :rtype: dict
+        """
+        agent = dict()
+        if has_request_context() and request.remote_addr:
+            agent['ip_address'] = request.remote_addr
+            if current_user.is_authenticated and current_user.email:
+                agent['email'] = current_user.email
+        return agent
+
+    @property
+    def id(self):
+        """Return the ID of the associated model."""
+        return self.model.id
+
+    # read only as it shouldn't change
+    @property
+    def user(self):
+        """Return the user of the associated model."""
+        return self.model.user
+
+    # read only as it shouldn't change
+    @property
+    def agent(self):
+        """Return the agent of the associated model."""
+        return self.model.agent
+
+    # read only as it shouldn't change
+    @property
+    def archivable(self):
+        """Tell if the SIP should be archived."""
+        return self.model.archivable
+
+    # read only as it shouldn't change
+    @property
+    def archived(self):
+        """Tell if the SIP has been archived."""
+        return self.model.archived
+
+    @archived.setter
+    def archived(self, is_archived):
+        """Change the archived status of the SIP.
+
+        :param bool is_archived: True if the SIP has been archived
+        """
+        self.model.archived = is_archived
+
+    @property
+    def files(self):
+        """Return the list of files associated with the SIP.
+
+        :rtype: list(:py:data:`invenio_sipstore.models.SIPFile`)
+        """
+        return self.model.sip_files
+
+    @property
+    def metadata(self):
+        """Return the list of metadata associated with the SIP.
+
+        :rtype: list(:py:data:`invenio_sipstore.models.SIPMetadata`)
+        """
+        return self.model.sip_metadata
+
+    def attach_file(self, file):
+        """Add a file to the SIP.
+
+        :param file: the file to attach. It must at least implement a `key`
+        and a valid `file_id`. See
+        :py:class:`invenio-files_rest.models.ObjectVersion`.
+        :returns: the created SIPFile
+        :rtype: :py:data:`invenio_sipstore.models.SIPFile`
+        """
+        sf = SIPFile(sip_id=self.id, filepath=file.key, file_id=file.file_id)
+        db.session.add(sf)
+        return sf
+
+    def attach_metadata(self, metadata, format='json'):
+        """Add metadata to the SIP.
+
+        :param str metadata: the metadata to attach.
+        :param str format: the format of metadata (json, marcxml...)
+        :returns: the created SIPMetadata
+        :rtype: :py:data:`invenio_sipstore.models.SIPMetadata`
+        """
+        sm = SIPMetadata(sip_id=self.id, format=format, content=metadata)
+        db.session.add(sm)
+        return sm
+
+    @classmethod
+    def create(cls, archivable, files=None, metadata=None, user_id=None,
+               agent=None):
+        """Create a SIP, from the PID and the Record.
+
+        Apart from the SIP itself, it also creates ``SIPFile`` objects for
+        each of the files in the record, along with ``SIPMetadata`` for the
+        metadata.
+        Those objects are not returned by this function but can be fetched by
+        the corresponding SIP attributes 'files' and 'metadata'.
+        The created model is stored in the attribute 'model'.
+        :param bool archivable: tells if the SIP should be archived or not.
+        Usefull if ``Invenio-Archivematica`` is installed.
+        :param list files: The list of files to associate with the SIP. See
+        :py:func:`invenio_sipstore.api.SIP.attach_file`
+        :param dict metadata: A dictionary of metadata. The keys are the
+        format (json, marcxml...) and the values are the content (string)
+        :param user_id: the ID of the user. If not given, automatically
+        computed
+        :param agent: If not given, automatically computed
+        :returns: API SIP object.
+        :rtype: :py:class:`invenio_sipstore.api.SIP`
+        """
+        if not user_id:
+            user_id = (None if current_user.is_anonymous
+                       else current_user.get_id())
+        if not agent:
+            agent_factory = import_string(
+                current_app.config['SIPSTORE_AGENT_FACTORY'])
+            agent = agent_factory()
+        files = [] if not files else files
+        metadata = {} if not metadata else metadata
+
+        with db.session.begin_nested():
+            sip = cls(SIP_.create(user_id=user_id, agent=agent,
+                                  archivable=archivable))
+            for f in files:
+                sip.attach_file(f)
+            for format, content in metadata.items():
+                sip.attach_metadata(content, format)
+        sipstore_created.send(sip)
+        return sip
+
+
+class RecordSIP(object):
+    """API for managing SIPRecords."""
+
+    def __init__(self, recordsip, sip):
+        """Constructor.
+
+        :param recordsip: the RecordSIP model to manage
+        :type recordsip: :py:data:`invenio_sipstore.models.RecordSIP`
+        :param sip: the SIP associated
+        :type sip: :py:data:`invenio_sipstore.api.SIP`
+        """
+        self.model = recordsip
+        self.__sip = sip
+
+    # we make it unwritable
+    @property
+    def sip(self):
+        """Return the SIP corresponding to this record.
+
+        :rtype: :py:class:`invenio_sipstore.api.SIP`
+        """
+        return self.__sip
+
+    @classmethod
+    def create(cls, pid, record, archivable, create_sip_files=True,
+               user_id=None, agent=None):
+        """Create a SIP, from the PID and the Record.
+
+        Apart from the SIP itself, it also creates ``RecordSIP`` for the
+        SIP-PID-Record relationship, as well as ``SIPFile`` objects for each
+        of the files in the record, along with ``SIPMetadata`` for the
+        metadata.
+        Those objects are not returned by this function but can be fetched by
+        the corresponding RecordSIP attributes 'sip', 'sip.files' and
+        'sip.metadata'.
+        :param pid: PID of the published record ('recid').
+        :type pid: `invenio_pidstore.models.PersistentIdentifier`
+        :param record: Record for which the SIP should be created.
+        :type record: `invenio_records.api.Record`
+        :param bool archivable: tells if the record should be archived.
+        Usefull when ``Invenio-Archivematica`` is installed.
+        :param bool create_sip_files: If True the SIPFiles will be created.
+        :returns: RecordSIP object.
+        :rtype: :py:class:`invenio_sipstore.api.RecordSIP`
+        """
+        files = record.files if create_sip_files else None
+        metadata = {'json': json.dumps(record.dumps())}
+        with db.session.begin_nested():
+            sip = SIP.create(archivable, files=files, metadata=metadata,
+                             user_id=user_id, agent=agent)
+            model = RecordSIP_(sip_id=sip.id, pid_id=pid.id)
+            db.session.add(model)
+            recsip = cls(model, sip)
+        return recsip

--- a/invenio_sipstore/models.py
+++ b/invenio_sipstore/models.py
@@ -66,13 +66,13 @@ class SIP(db.Model, Timestamp):
     """Agent information regarding given SIP."""
 
     archivable = db.Column(
-        db.Boolean(name='ck_sip_archivable'),
+        db.Boolean(name='ck_sipstore_archivable'),
         nullable=False,
         default=True)
     """Boolean stating if the SIP should be archived or not."""
 
     archived = db.Column(
-        db.Boolean(name='ck_sip_archived'),
+        db.Boolean(name='ck_sipstore_archived'),
         nullable=False,
         default=False)
     """Boolean stating if the SIP has been archived or not."""
@@ -140,6 +140,11 @@ class SIPFile(db.Model, Timestamp):
         db.ForeignKey(FileInstance.id, ondelete='RESTRICT'),
         nullable=False)
     """Id of the FileInstance."""
+
+    @property
+    def storage_location(self):
+        """Return the location of the file in the current storage."""
+        return self.file.uri
 
     @validates('filepath')
     def validate_key(self, filepath, filepath_):

--- a/invenio_sipstore/models.py
+++ b/invenio_sipstore/models.py
@@ -56,12 +56,6 @@ class SIP(db.Model, Timestamp):
     id = db.Column(UUIDType, primary_key=True, default=uuid.uuid4)
     """Id of SIP."""
 
-    sip_format = db.Column(db.String(7), nullable=False)
-    """Format of the SIP content ('json', 'marcxml' etc.)"""
-
-    content = db.Column(db.Text, nullable=False)
-    """Text blob of the SIP content."""
-
     user_id = db.Column(db.Integer,
                         db.ForeignKey(User.id),
                         nullable=True,
@@ -71,6 +65,18 @@ class SIP(db.Model, Timestamp):
     agent = db.Column(JSONType, default=lambda: dict(), nullable=False)
     """Agent information regarding given SIP."""
 
+    archivable = db.Column(
+        db.Boolean(name='ck_sip_archivable'),
+        nullable=False,
+        default=True)
+    """Boolean stating if the SIP should be archived or not."""
+
+    archived = db.Column(
+        db.Boolean(name='ck_sip_archived'),
+        nullable=False,
+        default=False)
+    """Boolean stating if the SIP has been archived or not."""
+
     #
     # Relationships
     #
@@ -78,17 +84,16 @@ class SIP(db.Model, Timestamp):
     """Relation to the User responsible for the SIP."""
 
     @classmethod
-    def create(cls, sip_format, content, user_id=None, agent=None, id_=None):
+    def create(cls, user_id=None, agent=None, id_=None, archivable=True,
+               archived=False):
         """Create a Submission Information Package object.
 
-        :param sip_format: Format of the SIP content (e.g. 'json', 'marcxml').
-        :type sip_format: str
-        :param content: Text blob of the SIP content.
-        :type content: str
         :param user_id: Id of the user responsible for the SIP.
         :type user_id: int
         :param agent: Extra information on submitting agent in JSON format.
         :type agent: dict
+        :param bool archivable: Tells if the SIP should be archived or not.
+        :param bool archived: Tells if the SIP has been archived.
         """
         if user_id and (User.query.get(user_id) is None):
             raise SIPUserDoesNotExist(user_id)
@@ -108,10 +113,10 @@ class SIP(db.Model, Timestamp):
         with db.session.begin_nested():
             obj = cls(
                 id=id_ or uuid.uuid4(),
-                sip_format=sip_format,
-                content=content,
                 user_id=user_id,
-                agent=agent
+                agent=agent,
+                archivable=archivable,
+                archived=archived
             )
             db.session.add(obj)
         return obj
@@ -153,6 +158,31 @@ class SIPFile(db.Model, Timestamp):
     file = db.relationship(FileInstance, backref='sip_files',
                            foreign_keys=[file_id])
     """Relation to the SIP along which given file was submitted."""
+
+
+class SIPMetadata(db.Model, Timestamp):
+    """Extra SIP info regarding metadata."""
+
+    __tablename__ = 'sipstore_sipmetadata'
+
+    id = db.Column(UUIDType, primary_key=True, default=uuid.uuid4)
+    """Id of metadata."""
+
+    sip_id = db.Column(UUIDType,
+                       db.ForeignKey(SIP.id, name='fk_sipmetadata_sip_id'))
+    """Id of SIP."""
+
+    format = db.Column(db.String(7), nullable=False)
+    """Format of the metadata content ('json', 'marcxml' etc.)"""
+
+    content = db.Column(db.Text, nullable=False)
+    """Text blob of the metadata content."""
+
+    #
+    # Relations
+    #
+    sip = db.relationship(SIP, backref='sip_metadata', foreign_keys=[sip_id])
+    """Relation to the SIP along which given metadata was submitted."""
 
 
 class RecordSIP(db.Model, Timestamp):

--- a/invenio_sipstore/signals.py
+++ b/invenio_sipstore/signals.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,20 +22,26 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Default configuration of Invenio-SIPStore module."""
+"""Signals for the module."""
 
-SIPSTORE_DEFAULT_AGENT_JSONSCHEMA = 'sipstore/agent-v1.0.0.json'
-"""Default JSON schema for extra SIP agent information.
+from blinker import Namespace
 
-For more examples, you can have a look at Zenodo's config:
-https://github.com/zenodo/zenodo/tree/master/zenodo/modules/sipstore/jsonschemas/sipstore
+_signals = Namespace()
+
+sipstore_created = _signals.signal('sipstore_created')
+"""Signal sent each time a SIP has been created.
+
+Send the SIP as a parameter: :py:class:`invenio_sipstore.api.SIP`
+
+Example subscriber
+
+.. code-block:: python
+
+    def listener(sender, *args, **kwargs):
+        # sender is the SIP being archived
+        for f in sender.files:
+            print(f.filepath)
+
+    from invenio_sipstore.signals import sipstore_created
+    sipstore_created.connect(listener)
 """
-
-SIPSTORE_AGENT_JSONSCHEMA_ENABLED = True
-"""Enable SIP agent validation by default."""
-
-SIPSTORE_AGENT_FACTORY = 'invenio_sipstore.api.SIP._build_agent_info'
-"""Factory to build the agent, stored for the information about the SIP."""
-
-SIPSTORE_FILEPATH_MAX_LEN = 1024
-"""Max filepath length."""

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,8 @@ setup(
             'invenio_sipstore_sip = invenio_sipstore.admin:sip_adminview',
             'invenio_sipstore_sipfile = '
             'invenio_sipstore.admin:sipfile_adminview',
+            'invenio_sipstore_sipmetadata = '
+            'invenio_sipstore.admin:sipmetadata_adminview',
             'invenio_sipstore_recordsip = '
             'invenio_sipstore.admin:recordsip_adminview',
         ]

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,12 @@ history = open('CHANGES.rst').read()
 tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
+    'invenio-records-files>=1.0.0a9',
     'isort>=4.2.2',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
+    'pytest-mock>=1.6.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
 ]
@@ -66,7 +68,7 @@ install_requires = [
     'invenio-accounts>=1.0.0a10',
     'invenio-pidstore>=1.0.0a7',
     'invenio-jsonschemas>=1.0.0a3',
-    'invenio-files-rest>=1.0.0a1',
+    'invenio-files-rest>=1.0.0a14',
     'jsonschema>=2.5.1',
 ]
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import, print_function
 from flask_admin import Admin, menu
 
 from invenio_sipstore.admin import recordsip_adminview, sip_adminview, \
-    sipfile_adminview
+    sipfile_adminview, sipmetadata_adminview
 
 
 def test_admin(db, app):
@@ -36,7 +36,8 @@ def test_admin(db, app):
     admin = Admin(app, name="AdminExt")
 
     # Register models in admin
-    for adminview in (sip_adminview, sipfile_adminview, recordsip_adminview):
+    for adminview in (sip_adminview, sipfile_adminview, recordsip_adminview,
+                      sipmetadata_adminview):
         assert 'model' in adminview
         assert 'modelview' in adminview
         admin_kwargs = dict(adminview)
@@ -58,6 +59,8 @@ def test_admin(db, app):
     assert 'SIP' in submenu_items
     assert 'RecordSIP' in submenu_items
     assert 'SIPFile' in submenu_items
+    assert 'SIPMetadata' in submenu_items
     assert isinstance(submenu_items['SIP'], menu.MenuView)
     assert isinstance(submenu_items['RecordSIP'], menu.MenuView)
     assert isinstance(submenu_items['SIPFile'], menu.MenuView)
+    assert isinstance(submenu_items['SIPMetadata'], menu.MenuView)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""Module tests."""
+
+from __future__ import absolute_import, print_function
+
+import json
+import tempfile
+import uuid
+from shutil import rmtree
+
+from invenio_accounts.testutils import create_test_user
+from invenio_files_rest.models import Bucket, Location, ObjectVersion
+from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+from invenio_records_files.api import Record
+from invenio_records_files.models import RecordsBuckets
+from six import BytesIO
+
+from invenio_sipstore.api import SIP, RecordSIP
+from invenio_sipstore.models import SIP as SIP_
+from invenio_sipstore.models import RecordSIP as RecordSIP_
+from invenio_sipstore.models import SIPFile, SIPMetadata
+
+
+def test_SIP(db):
+    """Test SIP API class."""
+    user = create_test_user('test@example.org')
+    agent = {'email': 'user@invenio.org', 'ip_address': '1.1.1.1'}
+    # we create a SIP model
+    sip = SIP_.create(user_id=user.id, agent=agent)
+    db.session.commit()
+    # We create an API SIP on top of it
+    api_sip = SIP(sip)
+    assert api_sip.model is sip
+    assert api_sip.id == sip.id
+    assert api_sip.user is user
+    assert api_sip.agent == agent
+    assert api_sip.archivable is True
+    assert api_sip.archived is False
+    api_sip.archived = True
+    db.session.commit()
+    assert api_sip.archived is True
+    assert sip.archived is True
+
+
+def test_SIP_files(db):
+    """Test the files methods of API SIP."""
+    # we create a SIP model
+    sip = SIP_.create()
+    db.session.commit()
+    # We create an API SIP on top of it
+    api_sip = SIP(sip)
+    assert len(api_sip.files) == 0
+    # we setup a file storage
+    tmppath = tempfile.mkdtemp()
+    db.session.add(Location(name='default', uri=tmppath, default=True))
+    db.session.commit()
+    # we create a file
+    content = b'test lol\n'
+    bucket = Bucket.create()
+    obj = ObjectVersion.create(bucket, 'test.txt', stream=BytesIO(content))
+    db.session.commit()
+    # we attach it to the SIP
+    sf = api_sip.attach_file(obj)
+    db.session.commit()
+    assert len(api_sip.files) == 1
+    assert api_sip.files[0].filepath == 'test.txt'
+    assert sip.sip_files[0].filepath == 'test.txt'
+    # finalization
+    rmtree(tmppath)
+
+
+def test_SIP_metadata(db):
+    """Test the metadata methods of API SIP."""
+    # we create a SIP model
+    sip = SIP_.create()
+    db.session.commit()
+    # We create an API SIP on top of it
+    api_sip = SIP(sip)
+    assert len(api_sip.metadata) == 0
+    # we create a dummy metadata
+    metadata = json.dumps({'this': 'is', 'not': 'sparta'})
+    # we attach it to the SIP
+    sm = api_sip.attach_metadata(metadata)
+    db.session.commit()
+    assert len(api_sip.metadata) == 1
+    assert api_sip.metadata[0].format == 'json'
+    assert api_sip.metadata[0].content == metadata
+    assert sip.sip_metadata[0].content == metadata
+
+
+def test_SIP_build_agent_info(app, mocker):
+    """Test SIP._build_agent_info static method."""
+    # with no information, we get an empty dict
+    agent = SIP._build_agent_info()
+    assert agent == {}
+    # we mock flask function to give more info
+    mocker.patch('invenio_sipstore.api.has_request_context',
+                 return_value=True, autospec=True)
+    mock_request = mocker.patch('invenio_sipstore.api.request')
+    type(mock_request).remote_addr = mocker.PropertyMock(
+        return_value="localhost")
+    mock_current_user = mocker.patch('invenio_sipstore.api.current_user')
+    type(mock_current_user).is_authenticated = mocker.PropertyMock(
+        return_value=True)
+    type(mock_current_user).email = mocker.PropertyMock(
+        return_value='test@invenioso.org')
+    agent = SIP._build_agent_info()
+    assert agent == {
+        'ip_address': 'localhost',
+        'email': 'test@invenioso.org'
+    }
+
+
+def test_SIP_create(app, db, mocker):
+    """Test the create method from SIP API."""
+    # we setup a file storage
+    tmppath = tempfile.mkdtemp()
+    db.session.add(Location(name='default', uri=tmppath, default=True))
+    db.session.commit()
+    # we create a file
+    content = b'test lol\n'
+    bucket = Bucket.create()
+    obj = ObjectVersion.create(bucket, 'test.txt', stream=BytesIO(content))
+    db.session.commit()
+    files = [obj]
+    # setup meetadata
+    metadata = {
+        'json': json.dumps({'this': 'is', 'not': 'sparta'}),
+        'marcxml': '<record></record>'
+    }
+    # Let's create a SIP
+    user = create_test_user('test@example.org')
+    agent = {'email': 'user@invenio.org', 'ip_address': '1.1.1.1'}
+    sip = SIP.create(True, files=files, metadata=metadata, user_id=user.id,
+                     agent=agent)
+    db.session.commit()
+    assert SIP_.query.count() == 1
+    assert len(sip.files) == 1
+    assert len(sip.metadata) == 2
+    assert SIPFile.query.count() == 1
+    assert SIPMetadata.query.count() == 2
+    assert sip.user.id == user.id
+    assert sip.agent == agent
+    # we mock the user and the agent to test if the creation works
+    app.config['SIPSTORE_AGENT_JSONSCHEMA_ENABLED'] = False
+    mock_current_user = mocker.patch('invenio_sipstore.api.current_user')
+    type(mock_current_user).is_anonymous = mocker.PropertyMock(
+        return_value=True)
+    sip = SIP.create(True, files=files, metadata=metadata)
+    assert sip.model.user_id is None
+    assert sip.user is None
+    assert sip.agent == {}
+    # finalization
+    rmtree(tmppath)
+
+
+def test_RecordSIP(db):
+    """Test RecordSIP API class."""
+    user = create_test_user('test@example.org')
+    agent = {'email': 'user@invenio.org', 'ip_address': '1.1.1.1'}
+    # we create a record
+    recid = uuid.uuid4()
+    pid = PersistentIdentifier.create(
+        'recid',
+        '1337',
+        object_type='rec',
+        object_uuid=recid,
+        status=PIDStatus.REGISTERED)
+    title = {'title': 'record test'}
+    record = Record.create(title, recid)
+    # we create the models
+    sip = SIP.create(True, user_id=user.id, agent=agent)
+    recordsip = RecordSIP_(sip_id=sip.id, pid_id=pid.id)
+    db.session.commit()
+    # We create an API SIP on top of it
+    api_recordsip = RecordSIP(recordsip, sip)
+    assert api_recordsip.model is recordsip
+    assert api_recordsip.sip.id == sip.id
+
+
+def test_RecordSIP_create(db):
+    """Test create method from the API class RecordSIP."""
+    # we setup a file storage
+    tmppath = tempfile.mkdtemp()
+    db.session.add(Location(name='default', uri=tmppath, default=True))
+    db.session.commit()
+    # first we create a record
+    recid = uuid.uuid4()
+    pid = PersistentIdentifier.create(
+        'recid',
+        '1337',
+        object_type='rec',
+        object_uuid=recid,
+        status=PIDStatus.REGISTERED)
+    record = Record.create({'title': 'record test'}, recid)
+    # we add a file to the record
+    bucket = Bucket.create()
+    content = b'Test file\n'
+    RecordsBuckets.create(record=record.model, bucket=bucket)
+    record.files['test.txt'] = BytesIO(content)
+    db.session.commit()
+    # Let's create a SIP
+    user = create_test_user('test@example.org')
+    agent = {'email': 'user@invenio.org', 'ip_address': '1.1.1.1'}
+    rsip = RecordSIP.create(pid, record, True, user_id=user.id, agent=agent)
+    db.session.commit()
+    # test!
+    assert RecordSIP_.query.count() == 1
+    assert SIP_.query.count() == 1
+    assert SIPFile.query.count() == 1
+    assert SIPMetadata.query.count() == 1
+    assert len(rsip.sip.files) == 1
+    assert len(rsip.sip.metadata) == 1
+    metadata = rsip.sip.metadata[0]
+    assert metadata.format == 'json'
+    assert '"title": "record test"' in metadata.content
+    assert rsip.sip.archivable is True
+    # we try with no files
+    rsip = RecordSIP.create(pid, record, True, create_sip_files=False,
+                            user_id=user.id, agent=agent)
+    assert SIPFile.query.count() == 1
+    assert SIPMetadata.query.count() == 2
+    assert len(rsip.sip.files) == 0
+    assert len(rsip.sip.metadata) == 1
+    # finalization
+    rmtree(tmppath)


### PR DESCRIPTION
Support for Invenio-Archivematica (see #25)

- Added an API to manage the models
- Added a signal sent each time a SIP is created
- Changed models:
    - added `archivable` and `archived` booleans on SIP
    - added a `SIPMetadata` table to enable the storage of multiple metadata
- Tests updated

API based on https://github.com/zenodo/zenodo/blob/master/zenodo/modules/sipstore/api.py