### PR TITLE
archivers: addition of 'lightweight' archiving for BagIt

### DIFF
--- a/invenio_sipstore/archivers/bagit_archiver.py
+++ b/invenio_sipstore/archivers/bagit_archiver.py
@@ -24,19 +24,28 @@
 
 """Archivers for SIP."""
 
+import json
+from copy import deepcopy
 from datetime import datetime
 
 from fs.path import join
+from invenio_db import db
 
 from invenio_sipstore.archivers import BaseArchiver
+from invenio_sipstore.models import SIPMetadata, SIPMetadataType
 
 
 class BagItArchiver(BaseArchiver):
     """BagIt archiver for SIP files."""
 
+    # Name of the SIPMetadataType for internal use of BagItArchiver
+    bagit_metadata_type_name = 'bagit'
+
     def __init__(self, sip, tags=None):
         """Constuctor.
 
+        :param sip: API instance of the SIP that is to be archived.
+        :type sip: invenio_sipstore.api.SIP
         :param dict tags: a dictionnary for the tags of the bagit
         """
         super(BagItArchiver, self).__init__(sip)
@@ -54,25 +63,140 @@ class BagItArchiver(BaseArchiver):
         return files + ['manifest-md5.txt', 'bagit.txt', 'bag-info.txt',
                         'tagmanifest-md5.txt']
 
-    def create(self):
+    @property
+    def bagit_metadata_type(self):
+        """Property for the metadata type for BagIt generation."""
+        return SIPMetadataType.get_from_name(self.bagit_metadata_type_name)
+
+    def bagit_metadata(self, sip):
+        """Property for fetching the BagIt metadata object."""
+        bagit_meta = SIPMetadata.query.filter_by(
+            sip_id=sip.id, type_id=self.bagit_metadata_type.id).one()
+        return json.loads(bagit_meta.content)
+
+    def create_bagit_metadata(self, content):
+        """Create the BagIt metadata object."""
+        with db.session.begin_nested():
+            obj = SIPMetadata(sip_id=self.sip.id,
+                              type_id=self.bagit_metadata_type.id,
+                              content=content)
+            db.session.add(obj)
+
+    def create(self, create_bagit_metadata=False, patch_of=None,
+               include_missing_files=False, filesdir="data/files",
+               metadatadir="data/metadata"):
         """Archive the SIP generating a BagIt file.
 
-        :returns: a dictionnary with the filenames as keys, and size and
+        When specifying 'patch_of' parameter the 'include_missing_files'
+        flag determines whether files that are missing in the archived SIP
+        (w.r.t. the SIP specified in 'patch_of') should be treated as
+        explicitly deleted (include_missing_files=False) or if they
+        should still be included in the manifest.
+
+        Example:
+            include_missing_files = True
+              SIP_1:
+                SIPFiles: a.txt, b.txt
+                BagIt Manifest: a.txt, b.txt
+              SIP_2 (Bagged with patch_of=SIP_1):
+                SIPFiles: b.txt, c.txt
+                BagIt Manifest: a.txt, b.txt, c.txt
+                fetch.txt: a.txt, b.txt
+
+            include_missing_files = False
+              SIP_1:
+                SIPFiles: a.txt, b.txt
+                BagIt Manifest: a.txt, b.txt
+              SIP_2 (Bagged with patch_of=SIP_1):
+                SIPFIles: b.txt, c.txt
+                BagIt Manifest: b.txt, c.txt
+                fetch.txt: b.txt
+
+        :param bool create_bagit_metadata: At the end of archiving,
+            create a SIPMetadata object for this SIP, which
+            will contain the metadata of the BagIt contents.
+            It is necessary to bag the SIPs with this option enabled, if
+            one wants to make use of 'patch_of' later on.
+        :param patch_of: Write a lightweight BagIt, which will archive only
+            the new files, and refer to the repeated ones in "fetch.txt" file.
+            The provided argument is a SIP, which will be taken as a base
+            for determining the "diff" between two bags.
+            Provided SIP needs to have a special 'bagit'-named SIPMetadata
+            object associated with it, i.e. it had to have been previously
+            archived with the 'create_bagit_metadata' flag.
+        :type patch_of: invenio_sipstore.models.SIP or None
+        :type bool include_missing_files: If set to True and if 'patch_of' is
+            used, include the files that are missing in the SIP w.r.t. to
+            the 'patch_of' SIP in the manifest.
+            The opposite (include_missing_files=False) is equivalent to
+            treating those as explicitly deleted - the files will not be
+            included in the manifest, nor in the "fetch.txt" file.
+        :returns: a dictionary with the filenames as keys, and size and
             checksum as value
         :rtype: dict
         """
+        sipfiles = self.sip.files
+        if patch_of:
+            fetch_info = {}
+            sipfiles = []  # We select SIPFiles for writing manually
+            sip_manifest = self.bagit_metadata(patch_of)['manifest']
+
+            # Helper mappings
+            # File UUID to manifest item mapping (select only the files data,
+            # not metadata files).
+            id2mi = dict((v['file_uuid'], dict(filename=k, meta=v)) for k, v in
+                         sip_manifest.items() if 'file_uuid' in v)
+            # File UUID to SIP File mapping
+            id2sf = dict((str(file.file.id), file) for file in self.sip.files)
+
+            manifest_files_s = set(id2mi.keys())
+            sip_files_s = set(id2sf.keys())
+            if include_missing_files:
+                fetched_uuids = manifest_files_s
+            else:
+                fetched_uuids = manifest_files_s & sip_files_s
+            stored_uuids = sip_files_s - manifest_files_s
+
+            for uuid in fetched_uuids:
+                if uuid in id2sf:
+                    filename = join(filesdir, id2sf[uuid].filepath)
+                else:
+                    filename = id2mi[uuid]['filename']
+                fetch_info[filename] = id2mi[uuid]['meta']
+
+            for uuid in stored_uuids:
+                sipfiles.append(id2sf[uuid])
+
+        # Copy the files
         files_info = super(BagItArchiver, self).create(
-            filesdir=join('data', 'files'), metadatadir='data')
+            filesdir=filesdir, metadatadir=metadatadir, sipfiles=sipfiles)
+        # Add the files from fetch.txt to the files_info dictionary,
+        # so they will be included in generated manifest-md5.txt file
+        if patch_of:
+            files_info.update(fetch_info)
 
         self.autogenerate_tags(files_info)
-
         metadata_info = self._save_file(*self.get_manifest_file(files_info))
+        if patch_of and fetch_info:
+            # Write the fetch.txt file if any of the files are to be fetched
+            metadata_info.update(
+                self._save_file(*self.get_fetch_file(fetch_info)))
         metadata_info.update(self._save_file(*self.get_bagit_file()))
         metadata_info.update(self._save_file(*self.get_baginfo_file()))
         metadata_info.update(
             self._save_file(*self.get_tagmanifest(metadata_info)))
 
+        if create_bagit_metadata:
+            # Create a SIPMetadata file, which will store metadata on what we
+            # have just archived using BagIt
+            bagit_meta = {}
+            bagit_meta['manifest'] = deepcopy(files_info)
+            if patch_of and fetch_info:
+                bagit_meta['fetch'] = deepcopy(fetch_info)
+            self.create_bagit_metadata(json.dumps(bagit_meta))
+
         files_info.update(metadata_info)
+
         return files_info
 
     def autogenerate_tags(self, files_info):
@@ -82,8 +206,14 @@ class BagItArchiver(BaseArchiver):
         self.tags['Payload-Oxum'] = '{0}.{1}'.format(
             sum([f['size'] for f in files_info.values()]), len(files_info))
 
+    def get_fetch_file(self, files_info):
+        """Generate the contents of the fetch.txt file."""
+        content = ('{0} {1} {2}'.format(c['path'], c['size'], f)
+                   for f, c in files_info.items())
+        return 'fetch.txt', '\n'.join(content)
+
     def get_manifest_file(self, files_info):
-        """Create the manifest file spcifying the checksum of the files.
+        """Create the manifest file specifying the checksum of the files.
 
         :return: the name of the file and its content
         :rtype: tuple

--- a/invenio_sipstore/archivers/base_archiver.py
+++ b/invenio_sipstore/archivers/base_archiver.py
@@ -95,25 +95,28 @@ class BaseArchiver(object):
         self.path = folder
         self._create_directories(folder)
 
-    def create(self, filesdir="", metadatadir="", sipfiles=None):
+    def create(self, filesdir="", metadatadir="", sipfiles=None,
+               dry_run=False):
         """Create the archive.
 
-        :param str filesdir: the directory where to put files if necessary
-        :param str metadatadir: the directory where to put metadata if
-            necessary
-        :param sipfiles: list of SIPFile objects to write. By default
+        :param str filesdir: directory to which the data files will be written.
+        :param str metadatadir: directory to which the metadata files will be
+            written.
+        :param sipfiles: a list of SIPFile objects to write. By default
             it's all of the SIPFiles attached to the SIP.
-        :returns: a dictionnary with the filenames as keys, and size and
-            checksum as value
-        :rtype: dict
+        :returns: a list with the dictionaries consiting of 'filename', 'size',
+            'checksum' and the 'path', which contains the absolute path on
+            the filesystem to which the file was written. Files from SIPFiles
+            contain also 'file_uuid' key, which is the UUID (primary key) of
+            the related FileInstance object.
         """
         sipfiles = sipfiles or self.sip.files
-        files_info = self._copy_files(sipfiles, filesdir)
+        files_info = self._copy_files(sipfiles, filesdir, dry_run=dry_run)
         metadata = self.get_metadata()
         for filename, content in metadata.items():
-            files_info.update(self._save_file(
+            files_info.append(self._save_file(
                 join(metadatadir, filename),
-                content))
+                content, dry_run=dry_run))
         return files_info
 
     def finalize(self):
@@ -132,7 +135,7 @@ class BaseArchiver(object):
         if not self.fs.exists(dirname):
             self.fs.makedir(dirname, recursive=True)
 
-    def _copy_files(self, files, filesdir=""):
+    def _copy_files(self, files, filesdir="", dry_run=False):
         """Copy the files inside the new storage.
 
         Takes care of adding self.path at the beginning.
@@ -140,11 +143,17 @@ class BaseArchiver(object):
         :param files: the list of files to copy
         :type files: list(:py:class:`invenio_sipstore.models.SIPFile`)
         :param str filesdir: the directory where to copy files
-        :returns: a dictionnary with the filenames as keys, and size and
-            checksum as value
-        :rtype: dict
+        :param bool dry_run: When True, the files will not be copied,
+            and only the file information will be returned. No changes will be
+            made to disk or the database.
+        :returns: a list with the dictionaries consiting of 'filename', 'size',
+            'checksum' and the 'path', which contains the absolute path on
+            the filesystem to which the file was written. Files from SIPFiles
+            contain also 'file_uuid' key, which is the UUID (primary key) of
+            the related FileInstance object.
+        :rtype: list(dict)
         """
-        result = {}
+        result = []
 
         total_size = sum([file.size for file in files])
         copied_size = 0
@@ -153,15 +162,16 @@ class BaseArchiver(object):
             src_fs, path = opener.parse(file.storage_location)
             filename = join(filesdir, file.filepath)
             calculated_filename = join(self.path, filename)
-            self._create_directories(dirname(calculated_filename))
-            copyfile(src_fs, path,
-                     self.fs, calculated_filename)
-            result[filename] = {
+            if not dry_run:
+                self._create_directories(dirname(calculated_filename))
+                copyfile(src_fs, path, self.fs, calculated_filename)
+            result.append({
+                'filename': filename,
                 'size': file.size,
                 'checksum': file.checksum,
                 'path': self.fs.getsyspath(calculated_filename),
                 'file_uuid': str(file.file.id)
-            }
+            })
             copied_size += file.size
 
             sipstore_archiver_status.send({
@@ -174,15 +184,19 @@ class BaseArchiver(object):
             })
         return result
 
-    def _save_file(self, filename, content):
+    def _save_file(self, filename, content, dry_run=False):
         """Save the content inside the file.
 
         Takes care of adding self.path in the filename.
 
         :param str filename: the name of the file
         :param str content: the content of the file
-        :returns: a dictionnary with the filenames as keys, and size and
-            checksum as value
+        :param bool dry_run: When True, the files will not be copied,
+            and only the file information will be returned. No changes will be
+            made to disk or the database.
+        :returns: a dictionary describing the saved file, containing 'filename'
+            'size', 'checksum' and 'path' which contains the absolute path on
+            the filesystem to which the file was written.
         :rtype: dict
 
         ..warning::
@@ -192,15 +206,14 @@ class BaseArchiver(object):
         """
         content = b(content)
         filenamepath = join(self.path, filename)
-        self._create_directories(dirname(filenamepath))
-
-        with self.fs.open(filenamepath, 'wb') as fp:
-            fp.write(content)
+        if not dry_run:
+            self._create_directories(dirname(filenamepath))
+            with self.fs.open(filenamepath, 'wb') as fp:
+                fp.write(content)
 
         return {
-            filename: {
-                'size': len(content),
-                'checksum': 'md5:' + str(md5(content).hexdigest()),
-                'path': self.fs.getsyspath(filenamepath)
-            }
+            'filename': filename,
+            'size': len(content),
+            'checksum': 'md5:' + str(md5(content).hexdigest()),
+            'path': self.fs.getsyspath(filenamepath)
         }

--- a/invenio_sipstore/jsonschemas/sipstore/bagit-v1.0.0.json
+++ b/invenio_sipstore/jsonschemas/sipstore/bagit-v1.0.0.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "BagIt Archiver metadata schema.",
+  "description": "Metadata for BagIt-archived SIPs.",
+  "definitions": {
+    "archived_file": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "filename": {
+          "description": "Filename of the file.",
+          "type": "string"
+        },
+        "path": {
+          "description": "Full path to the file in the archive.",
+          "type": "string"
+        },
+        "size": {
+          "description": "Size of the file in bytes.",
+          "type": "number"
+        },
+        "checksum": {
+          "description": "MD5 checksum of the file. Always starts with 'md5:' prefix.",
+          "type": "string"
+        },
+        "file_uuid": {
+          "description": "UUID of the related FileInstance object (if any).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "filename",
+        "size",
+        "checksum",
+        "path"
+      ]
+    }
+  },
+  "properties": {
+    "manifest": {
+      "description": "Files that are specified in the bag manifest.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/archived_file"
+      }
+    },
+    "fetch": {
+      "description": "Files that are fetched externally to complete the bag.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/archived_file"
+      }
+    }
+  }
+}

--- a/invenio_sipstore/jsonschemas/sipstore/bagit-v1.0.0.json
+++ b/invenio_sipstore/jsonschemas/sipstore/bagit-v1.0.0.json
@@ -4,16 +4,16 @@
   "title": "BagIt Archiver metadata schema.",
   "description": "Metadata for BagIt-archived SIPs.",
   "definitions": {
-    "archived_file": {
+    "file": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "filename": {
-          "description": "Filename of the file.",
+          "description": "Path to the file relative to the bag root.",
           "type": "string"
         },
         "path": {
-          "description": "Full path to the file in the archive.",
+          "description": "Full path to the file in the archive system.",
           "type": "string"
         },
         "size": {
@@ -25,31 +25,39 @@
           "type": "string"
         },
         "file_uuid": {
-          "description": "UUID of the related FileInstance object (if any).",
+          "description": "UUID of the related FileInstance object. Used for Record's data files only.",
           "type": "string"
+        },
+        "content": {
+          "description": "Text-content of the file. Used for BagIt metadata files only.",
+          "type": "string"
+        },
+        "fetched": {
+          "description": "Marks whether given file is fetched from another bag (specified in 'fetch.txt'). If the key does not exist or is set to false, it is assumed that the file is written down in the bag, hence NOT fetched. Used for Record's data files only.",
+          "type": "boolean"
         }
       },
       "required": [
         "filename",
+        "path",
         "size",
-        "checksum",
-        "path"
+        "checksum"
       ]
     }
   },
   "properties": {
-    "manifest": {
-      "description": "Files that are specified in the bag manifest.",
+    "datafiles": {
+      "description": "Files that are specified in the bag manifest as data. This includes both the Record's data files as well as metadata dumps.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/archived_file"
+        "$ref": "#/definitions/file"
       }
     },
-    "fetch": {
-      "description": "Files that are fetched externally to complete the bag.",
+    "bagitfiles": {
+      "description": "BagIt metadata files.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/archived_file"
+        "$ref": "#/definitions/file"
       }
     }
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,8 @@ from sqlalchemy_utils.functions import create_database, database_exists, \
     drop_database
 
 from invenio_sipstore import InvenioSIPStore
-from invenio_sipstore.models import SIP, SIPFile
+from invenio_sipstore.archivers import BagItArchiver
+from invenio_sipstore.models import SIP, SIPFile, SIPMetadataType
 
 
 @pytest.yield_fixture(scope='session')
@@ -107,6 +108,33 @@ def dummy_location(db, instance_path):
     db.session.add(loc)
     db.session.commit()
     return loc
+
+
+@pytest.fixture()
+def sip_metadata_types(db):
+    """Add a SIP metadata type (internal use only) for BagIt."""
+    bagit_type = SIPMetadataType(
+        title='BagIt Archiver Metadata',
+        name=BagItArchiver.bagit_metadata_type_name,
+        format='json',
+        )
+    json_type = SIPMetadataType(
+        title='Record JSON Metadata',
+        name='json-test',
+        format='json')
+
+    xml_type = SIPMetadataType(
+        title='Record XML Metadata',
+        name='xml-test',
+        format='xml')
+
+    db.session.add(bagit_type)
+    db.session.add(json_type)
+    db.session.add(xml_type)
+    db.session.commit()
+    types = dict((t.name, t) for t in [bagit_type, json_type, xml_type])
+
+    return types
 
 
 @pytest.fixture()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,23 +22,12 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Default configuration of Invenio-SIPStore module."""
 
-SIPSTORE_DEFAULT_AGENT_JSONSCHEMA = 'sipstore/agent-v1.0.0.json'
-"""Default JSON schema for extra SIP agent information.
+"""Pytest helpers."""
 
-For more examples, you can have a look at Zenodo's config:
-https://github.com/zenodo/zenodo/tree/master/zenodo/modules/sipstore/jsonschemas/sipstore
-"""
+from __future__ import absolute_import, print_function
 
-SIPSTORE_DEFAULT_BAGIT_JSONSCHEMA = 'sipstore/bagit-v1.0.0.json'
-"""Default JSON schema for BagIt archiver."""
 
-SIPSTORE_AGENT_JSONSCHEMA_ENABLED = True
-"""Enable SIP agent validation by default."""
-
-SIPSTORE_AGENT_FACTORY = 'invenio_sipstore.api.SIP._build_agent_info'
-"""Factory to build the agent, stored for the information about the SIP."""
-
-SIPSTORE_FILEPATH_MAX_LEN = 1024
-"""Max filepath length."""
+def get_file(filename, result):
+    """Get a file by its filename from the results list."""
+    return next((f for f in result if f['filename'] == filename), None)

--- a/tests/test_bagit_archiver.py
+++ b/tests/test_bagit_archiver.py
@@ -27,10 +27,13 @@
 from __future__ import absolute_import, print_function
 
 import pytest
+from invenio_files_rest.models import FileInstance
+from six import BytesIO
 
 from invenio_sipstore.api import SIP
 from invenio_sipstore.archivers import BagItArchiver
-from invenio_sipstore.models import SIPMetadataType
+from invenio_sipstore.models import SIP as SIPModel
+from invenio_sipstore.models import SIPFile
 
 
 def test_bagit_archiver_get_all_files(sip_with_file):
@@ -120,12 +123,10 @@ def test_bagit_archiver_get_tagmanifest():
     assert content == '13 file1'
 
 
-def test_bagit_archiver_create_archive(db, sip_with_file, tmp_archive_fs):
+def test_bagit_archiver_create_archive(db, sip_with_file, tmp_archive_fs,
+                                       sip_metadata_types):
     """Test the functions used to create an export of the SIP."""
     sip = SIP(sip_with_file)
-    mtype = SIPMetadataType(title='JSON Test', name='json-test',
-                            format='json', schema='url://to/schema')
-    db.session.add(mtype)
     sip.attach_metadata('json-test', '{"title": "json"}')
     db.session.commit()
     archiver = BagItArchiver(sip)
@@ -135,14 +136,14 @@ def test_bagit_archiver_create_archive(db, sip_with_file, tmp_archive_fs):
     assert tmp_archive_fs.isdir(path)
     # create
     result = archiver.create()
-    assert tmp_archive_fs.isfile('test/data/json-test.json')
+    assert tmp_archive_fs.isfile('test/data/metadata/json-test.json')
     assert tmp_archive_fs.isfile('test/data/files/foobar.txt')
     assert tmp_archive_fs.isfile('test/manifest-md5.txt')
     assert tmp_archive_fs.isfile('test/bagit.txt')
     assert tmp_archive_fs.isfile('test/bag-info.txt')
     assert tmp_archive_fs.isfile('test/tagmanifest-md5.txt')
     assert len(result) == 6
-    assert 'data/json-test.json' in result
+    assert 'data/metadata/json-test.json' in result
     assert 'data/files/foobar.txt' in result
     assert 'manifest-md5.txt' in result
     assert 'bagit.txt' in result
@@ -152,3 +153,182 @@ def test_bagit_archiver_create_archive(db, sip_with_file, tmp_archive_fs):
     archiver.finalize()
     assert archiver.path == ''
     assert not tmp_archive_fs.exists(path)
+
+
+@pytest.fixture
+def archived_bagit_sip(db, dummy_location, sip_with_file, tmp_archive_fs,
+                       sip_metadata_types):
+    """Fixture with two sips and multiple files for BagIt archiver tests."""
+    # For better example, add an extra file to the SIP
+    sip1 = SIP(sip_with_file)
+    file1 = sip1.files[0].file
+    file2 = FileInstance.create()
+    file2.set_contents(BytesIO(b'test-second'),
+                       default_location=dummy_location.uri)
+    sipfile2 = SIPFile(sip_id=sip1.id, filepath="foobar2.txt",
+                       file_id=file2.id)
+    db.session.add(sipfile2)
+    sip1.attach_metadata('json-test', '{"title": "JSON Meta"}')
+    db.session.commit()
+
+    archiver = BagItArchiver(sip1)
+    # init
+    archiver.init(tmp_archive_fs, 'test')
+    # create
+    archiver.create(create_bagit_metadata=True)
+
+    # Make a new SIP with one of the previous file and a new one
+    sip2 = SIP(SIPModel.create())
+    sip2.attach_metadata('json-test', '{"title": "JSON Meta 2"}')
+    sip2.attach_metadata('xml-test', '<p>XML Meta 2</p>')
+    file3 = FileInstance.create()
+    file3.set_contents(BytesIO(b'test-third'),
+                       default_location=dummy_location.uri)
+    # We name rename the filepath of the second SIP file on purpose
+    # ('foobar2.txt' -> 'foobar22.txt')
+    sip2file2 = SIPFile(sip_id=sip2.id, filepath="foobar2-renamed.txt",
+                        file_id=file2.id)
+    sip2file3 = SIPFile(sip_id=sip2.id, filepath="foobar3.txt",
+                        file_id=file3.id)
+
+    db.session.add(sip2file2)
+    db.session.add(sip2file3)
+    db.session.commit()
+
+    archiver = BagItArchiver(sip2)
+    archiver.init(tmp_archive_fs, 'test2')
+
+    return sip1, file1, file2, file3, archiver
+
+
+def test_bagit_archiver_create_archive_fetch_file(
+        archived_bagit_sip, dummy_location, db, sip_with_file,
+        tmp_archive_fs):
+    """Test the BagIt archiving with previous SIP as a base for diffing."""
+
+    sip1, file1, file2, file3, archiver = archived_bagit_sip
+    # create a BagIt for the SIP 2, but make it a patch of the SIP 1
+    result = archiver.create(create_bagit_metadata=True, patch_of=sip1,
+                             include_missing_files=True)
+
+    assert tmp_archive_fs.isfile('test2/data/metadata/json-test.json')
+    assert tmp_archive_fs.isfile('test2/data/metadata/xml-test.xml')
+
+    # The two referenced files should not exist in the archive
+    assert not tmp_archive_fs.isfile('test2/data/files/foobar.txt')
+    assert not tmp_archive_fs.isfile('test2/data/files/foobar2-renamed.txt')
+    # Ony the new one should
+    assert tmp_archive_fs.isfile('test2/data/files/foobar3.txt')
+
+    assert tmp_archive_fs.isfile('test2/manifest-md5.txt')
+    assert tmp_archive_fs.isfile('test2/fetch.txt')
+    assert tmp_archive_fs.isfile('test2/bagit.txt')
+    assert tmp_archive_fs.isfile('test2/bag-info.txt')
+    assert tmp_archive_fs.isfile('test2/tagmanifest-md5.txt')
+
+    assert len(result) == 10
+    assert 'data/metadata/json-test.json' in result
+    assert 'data/metadata/xml-test.xml' in result
+    assert 'data/files/foobar.txt' in result
+    # Check if the correct file was referenced
+    assert result['data/files/foobar.txt']['file_uuid'] == str(file1.id)
+    assert 'data/files/foobar2-renamed.txt' in result
+    assert result['data/files/foobar2-renamed.txt']['file_uuid'] == \
+        str(file2.id)
+    assert 'data/files/foobar3.txt' in result
+    assert 'manifest-md5.txt' in result
+    assert 'bagit.txt' in result
+    assert 'bag-info.txt' in result
+    assert 'tagmanifest-md5.txt' in result
+    assert 'fetch.txt' in result
+
+    # Should be specified in the fetch and manifest
+    with tmp_archive_fs.open('test2/fetch.txt') as fp:
+        expected_fetch = [
+            "{0} 4 data/files/foobar.txt".format(
+                tmp_archive_fs.getsyspath('test/data/files/foobar.txt')),
+            "{0} 11 data/files/foobar2-renamed.txt".format(
+                tmp_archive_fs.getsyspath('test/data/files/foobar2.txt')),
+            ]
+        fetch = fp.read().splitlines()
+        assert all(item in fetch for item in expected_fetch)
+
+    with tmp_archive_fs.open('test2/manifest-md5.txt') as fp:
+        expected_manifest = [
+            u'1963a365b400a214cf9b89354bcd6169 data/metadata/json-test.json',
+            u'3acfb5b50e960eece15dbed928d9e40f data/metadata/xml-test.xml',
+            u'098f6bcd4621d373cade4e832627b4f6 data/files/foobar.txt',
+            u'652b054df498ace88fef9857785fce34 data/files/foobar2-renamed.txt',
+            u'f1d2f9e84f147fed5fab05c6f8210c6f data/files/foobar3.txt',
+        ]
+
+        manifest = fp.read().splitlines()
+        assert all(item in manifest for item in expected_manifest)
+
+
+def test_bagit_archiver_create_archive_fetch_file_deleted(
+        archived_bagit_sip, dummy_location, db, sip_with_file,
+        tmp_archive_fs):
+    """
+    Test the BagIt archiving with previous SIP as a base for diffing.
+
+    Treats missing files as deleted.
+    """
+
+    sip1, file1, file2, file3, archiver = archived_bagit_sip
+    # create a BagIt for the SIP 2, but make it a patch of the SIP 1
+    result = archiver.create(create_bagit_metadata=True, patch_of=sip1,
+                             include_missing_files=False)
+
+    assert tmp_archive_fs.isfile('test2/data/metadata/json-test.json')
+    assert tmp_archive_fs.isfile('test2/data/metadata/xml-test.xml')
+
+    # The "deleted" (missing in SIP) file should not be archived
+    assert not tmp_archive_fs.isfile('test2/data/files/foobar.txt')
+    # The referenced file should not exist in the archive
+    assert not tmp_archive_fs.isfile('test2/data/files/foobar2-renamed.txt')
+    # Ony the new one should exist
+    assert tmp_archive_fs.isfile('test2/data/files/foobar3.txt')
+
+    assert tmp_archive_fs.isfile('test2/manifest-md5.txt')
+    assert tmp_archive_fs.isfile('test2/fetch.txt')
+    assert tmp_archive_fs.isfile('test2/bagit.txt')
+    assert tmp_archive_fs.isfile('test2/bag-info.txt')
+    assert tmp_archive_fs.isfile('test2/tagmanifest-md5.txt')
+
+    assert len(result) == 9
+    assert 'data/metadata/json-test.json' in result
+    assert 'data/metadata/xml-test.xml' in result
+    # The file ommited from SIP should not be specified
+    assert 'data/files/foobar.txt' not in result
+    # Check if the correct file was referenced
+    assert 'data/files/foobar2-renamed.txt' in result
+    assert result['data/files/foobar2-renamed.txt']['file_uuid'] == \
+        str(file2.id)
+    assert 'data/files/foobar3.txt' in result
+    assert 'manifest-md5.txt' in result
+    assert 'bagit.txt' in result
+    assert 'bag-info.txt' in result
+    assert 'tagmanifest-md5.txt' in result
+    assert 'fetch.txt' in result
+
+    # File should be specified in the fetch and manifest
+    with tmp_archive_fs.open('test2/fetch.txt') as fp:
+        expected_fetch = [
+            "{0} 11 data/files/foobar2-renamed.txt".format(
+                tmp_archive_fs.getsyspath('test/data/files/foobar2.txt')),
+            ]
+        fetch = fp.read().splitlines()
+        assert set(fetch) == set(expected_fetch)
+        assert all(item in fetch for item in expected_fetch)
+
+    with tmp_archive_fs.open('test2/manifest-md5.txt') as fp:
+        expected_manifest = [
+            u'1963a365b400a214cf9b89354bcd6169 data/metadata/json-test.json',
+            u'3acfb5b50e960eece15dbed928d9e40f data/metadata/xml-test.xml',
+            u'652b054df498ace88fef9857785fce34 data/files/foobar2-renamed.txt',
+            u'f1d2f9e84f147fed5fab05c6f8210c6f data/files/foobar3.txt',
+        ]
+
+        manifest = fp.read().splitlines()
+        assert set(manifest) == set(expected_manifest)


### PR DESCRIPTION
* Adds a functionality for BagIt archiver to write only
  the new files to the archive location, and refer to the
  already archived content in fetch.txt files.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>