### PR TITLE
global: include all SIP metadata types by default

### DIFF
--- a/invenio_sipstore/archivers/bagit_archiver.py
+++ b/invenio_sipstore/archivers/bagit_archiver.py
@@ -270,7 +270,9 @@ class BagItArchiver(BaseArchiver):
             for uuid in archived_uuids:
                 data_files.append(id2df[uuid])
 
-        metadata_files = self._get_metadata_files()
+        bagit_metadata_type = self._get_bagit_metadata_type()
+        metadata_files = [f for f in self._get_metadata_files()
+                          if f['metadata_id'] != bagit_metadata_type.id]
         extra_files = self._get_extra_files(data_files, metadata_files)
 
         bagit_files = []

--- a/invenio_sipstore/archivers/base_archiver.py
+++ b/invenio_sipstore/archivers/base_archiver.py
@@ -239,12 +239,9 @@ class BaseArchiver(object):
 
         :return: list of dict containing file information.
         """
-        # Consider only the explicitly-configured metadata types
-        m_names = current_app.config['SIPSTORE_ARCHIVER_METADATA_TYPES']
         files = []
         for m in self.sip.metadata:
-            if m.type.name in m_names:
-                files.append(self._generate_sipmetadata_info(m))
+            files.append(self._generate_sipmetadata_info(m))
         return files
 
     def _get_extra_files(self, data_files, metadata_files):
@@ -351,10 +348,9 @@ class BaseArchiver(object):
 
         By the default when 'filesinfo' is omitted, the base archiver
         will generate the file info for all attached SIPFiles and SIPMetadata
-        files (but only those which SIPMetadata.type.name was specified in the
-        `SIPSTORE_ARCHIVER_METADATA_TYPES`). Specific archivers are expected
-        to overwrite the `self.get_all_files` method, or craft the
-        `filesinfo` parameter of this method externally.
+        files. Specific archivers are expected to overwrite the
+        `self.get_all_files` method, or craft the `filesinfo` parameter of
+        this method externally.
 
         For more information on the structure of the file-info dict, see
         JSON Schema: invenio_sipstore.jsonschemas.sipstore.file-v1.0.0.json.

--- a/invenio_sipstore/config.py
+++ b/invenio_sipstore/config.py
@@ -51,9 +51,6 @@ SIPSTORE_ARCHIVER_LOCATION_NAME = 'archive'
 """Name of the invenio_files_rest.models.Location object, which will specify
 to the archive location in its URI."""
 
-SIPSTORE_ARCHIVER_METADATA_TYPES = ['json', ]
-"""List of metadata types (SIPMetadataType.name) to include in archiving."""
-
 SIPSTORE_BAGIT_TAGS = [
     ('Source-Organization', 'European Organization for Nuclear Research'),
     ('Organization-Address', 'CERN, CH-1211 Geneva 23, Switzerland'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,6 @@ def base_app(instance_path):
         SECURITY_PASSWORD_SALT='CHANGE_ME',
         SQLALCHEMY_DATABASE_URI=os.environ.get(
             'SQLALCHEMY_DATABASE_URI', 'sqlite:///test.db'),
-        SIPSTORE_ARCHIVER_METADATA_TYPES=['json-test', 'marcxml-test']
     )
     InvenioSIPStore(app)
     return app
@@ -118,9 +117,6 @@ def sip_metadata_types(db):
         title='Record MARCXML Metadata',
         name='marcxml-test',
         format='xml')
-    # The type 'txt-test' is intentionally ommited from the configuration
-    # (SIPSTORE_ARCHIVER_METADATA_TYPES). It should not be archived in any of
-    # the tests.
     txt_type = SIPMetadataType(
         title='Raw Text Metadata',
         name='txt-test',
@@ -131,7 +127,7 @@ def sip_metadata_types(db):
     db.session.add(xml_type)
     db.session.add(txt_type)
     db.session.commit()
-    types = dict((t.name, t) for t in [bagit_type, json_type, xml_type])
+    types = {t.name: t for t in [bagit_type, json_type, xml_type, txt_type]}
 
     return types
 

--- a/tests/test_bagit_archiver.py
+++ b/tests/test_bagit_archiver.py
@@ -52,7 +52,7 @@ def test_get_all_files(sips):
     """Test the function get_all_files."""
     archiver = BagItArchiver(sips[0])
     files = archiver.get_all_files()
-    assert len(files) == 8
+    assert len(files) == 9
 
 
 def test_write_all_files(sips, archive_fs):
@@ -69,7 +69,7 @@ def test_write_all_files(sips, archive_fs):
     assert set(fs.listdir('data')) == \
         set(['metadata', 'files', 'filenames.txt'])
     assert set(fs.listdir('data/metadata')) == \
-        set(['marcxml-test.xml', 'json-test.json', ])
+        set(['marcxml-test.xml', 'json-test.json', 'txt-test.txt'])
     assert set(fs.listdir('data/files')) == set(['foobar.txt', ])
 
 
@@ -139,7 +139,7 @@ def test_write_patched(mocker, sips, archive_fs,
     assert set(fs1.listdir('data')) == \
         set(['files', 'metadata', 'filenames.txt'])
     assert len(fs1.listdir('data/files')) == 1
-    assert len(fs1.listdir('data/metadata')) == 2
+    assert len(fs1.listdir('data/metadata')) == 3
 
     assert set(fs2.listdir('data')) == \
         set(['files', 'metadata', 'filenames.txt'])
@@ -182,6 +182,8 @@ def test_write_patched(mocker, sips, archive_fs,
             "{checksum} {filepath}".format(
                 **_read_file(fs1, 'data/metadata/json-test.json')),
             "{checksum} {filepath}".format(
+                **_read_file(fs1, 'data/metadata/txt-test.txt')),
+            "{checksum} {filepath}".format(
                 **_read_file(fs1, 'data/filenames.txt')),
         ])),
         ('data/filenames.txt', set([
@@ -191,7 +193,7 @@ def test_write_patched(mocker, sips, archive_fs,
             "Source-Organization: European Organization for Nuclear Research\n"
             "Organization-Address: CERN, CH-1211 Geneva 23, Switzerland\n"
             "Bagging-Date: {0}\n".format(dt) +
-            "Payload-Oxum: 93.4\n"
+            "Payload-Oxum: 105.5\n"
             "External-Identifier: {0}/SIPBagIt-v1.0.0\n".format(sips[0].id) +
             "External-Description: BagIt archive of SIP.\n"
             "X-Agent-Email: spiderpig@invenio.org\n"

--- a/tests/test_base_archiver.py
+++ b/tests/test_base_archiver.py
@@ -40,10 +40,10 @@ def test_getters(db, sips, sip_metadata_types, locations):
     assert data_files_info == [fi, ]
 
     metafiles_info = archiver._get_metadata_files()
-    assert len(metafiles_info) == 2
+    assert len(metafiles_info) == 3
     m1_abs_path = abs_path_fmt.format(filepath="metadata/json-test.json")
-    m2_abs_path = abs_path_fmt.format(
-        filepath="metadata/marcxml-test.xml")
+    m2_abs_path = abs_path_fmt.format(filepath="metadata/marcxml-test.xml")
+    m3_abs_path = abs_path_fmt.format(filepath="metadata/txt-test.txt")
     m1 = {
         'checksum': 'md5:da4ab7e4c4b762d8e2f3ec3b9f801b1f',
         'fullpath': m1_abs_path,
@@ -58,14 +58,23 @@ def test_getters(db, sips, sip_metadata_types, locations):
         'filepath': 'metadata/marcxml-test.xml',
         'size': 12
     }
+    m3 = {
+        'checksum': 'md5:d7aad7ac23351f42ecbf62cd637ea398',
+        'fullpath': m3_abs_path,
+        'metadata_id': sip_metadata_types['txt-test'].id,
+        'filepath': 'metadata/txt-test.txt',
+        'size': 12
+    }
     assert m1 in metafiles_info
     assert m2 in metafiles_info
+    assert m3 in metafiles_info
 
     all_files_info = archiver.get_all_files()
-    assert len(all_files_info) == 3
+    assert len(all_files_info) == 4
     assert fi in all_files_info
     assert m1 in all_files_info
     assert m2 in all_files_info
+    assert m3 in all_files_info
 
 
 def test_write(db, sips, sip_metadata_types, locations, archive_fs):
@@ -118,11 +127,12 @@ def test_write_all(db, sips, sip_metadata_types, locations, archive_fs):
     assert len(archive_fs.listdir()) == 1
     fs = archive_fs.opendir(archiver.get_archive_subpath())
     assert len(fs.listdir()) == 2
-    assert len(fs.listdir('metadata')) == 2
+    assert len(fs.listdir('metadata')) == 3
     assert len(fs.listdir('files')) == 1
     expected = {
             ('metadata/marcxml-test.xml', '<p>XML 1</p>'),
             ('metadata/json-test.json', '{"title": "JSON 1"}'),
+            ('metadata/txt-test.txt', 'Title: TXT 1'),
             ('files/foobar.txt', 'test'),
     }
     for fn, content in expected:


### PR DESCRIPTION
* Now archivers include by default all SIP metadata types when writing
  files. The BagIt archiver excludes the internally used "bagit" type.